### PR TITLE
Fix Barbara Howard's Canadian Encyclopedia URL.

### DIFF
--- a/src/data/element-json-fr.ts
+++ b/src/data/element-json-fr.ts
@@ -193,7 +193,7 @@ export const jsonData: IElement[] = [
     name: "Barbara Howard",
     dates: "05.08.1920 - 01.26.2017",
     urlLink:
-      "https://www.thecanadianencyclopedia.ca/fr/article/sandra-brewster",
+      "https://www.thecanadianencyclopedia.ca/fr/article/barbara-howard",
     imageUrl: "29.jpg",
     infoBlurb:
       "Barbara Howard, athlète, et éducatrice. Howard est connu comme la première athlète noire à représenter le Canada dans une compétition internationale. À seulement 17 ans, elle a battu le record de l'Empire britannique au 100 verges. En 1941, elle est devenue la première personne racialisée à être embauchée par le Vancouver School Board; elle a eu une carrière de 43 ans dans l'éducation, dont 14 ans en tant que professeur d'éducation physique.",

--- a/src/data/element-json.ts
+++ b/src/data/element-json.ts
@@ -192,7 +192,7 @@ export const jsonData: IElement[] = [
     name: "Barbara Howard",
     dates: "05.08.1920 - 01.26.2017",
     urlLink:
-      "https://www.thecanadianencyclopedia.ca/en/article/sandra-brewster",
+      "https://www.thecanadianencyclopedia.ca/en/article/barbara-howard",
     imageUrl: "29.jpg",
     infoBlurb:
       "Barbara Howard, athlete, and educator. Howard is believed to be the first Black female athlete to represent Canada in international competition. At only 17 years old, she broke the British Empire record for the 100-yard dash, qualifying to represent Canada at the 1938 British Empire Games in Sydney, Australia. In 1941, she became the first racialized person to be hired by the Vancouver School Board. She had a 43-year career in education, including 14 years as a physical education teacher.",


### PR DESCRIPTION
The link for Barbara Howard's URL to the Canadian Encyclopedia was the link for Sandra Brewster, so this commit changes it.